### PR TITLE
Add dns_zone var to the elb-dns-registrator job

### DIFF
--- a/helm/k8s-pub-auth-varnish/templates/elb-registrator-job.yaml
+++ b/helm/k8s-pub-auth-varnish/templates/elb-registrator-job.yaml
@@ -26,6 +26,11 @@ spec:
             configMapKeyRef:
               name: global-config
               key: dns_subdomain
+        - name: DomainZone
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: dns_zone
         - name: KONSTRUCTOR_API_KEY
           valueFrom:
             secretKeyRef:

--- a/helm/k8s-pub-auth-varnish/values.yaml
+++ b/helm/k8s-pub-auth-varnish/values.yaml
@@ -10,4 +10,4 @@ image:
   repository: coco/k8s-pub-auth-varnish
   pullPolicy: IfNotPresent
 elbRegistrator:
-  image: "coco/coco-elb-dns-registrator:5.0.1"
+  image: "coco/coco-elb-dns-registrator:5.1.0"


### PR DESCRIPTION
As part of the DNS migration we need to be able to configure the DNS zone provided to the Konstructor API. With this change upgrade the coco/coco-elb-dns-registrator version to 5.1.0. This version support the DomainZone parameter. Also, we add the DomainZone value to be taken from the global-config configmap dns_zone key.

This change depends on Financial-Times/upp-global-configs#89