### PR TITLE
Change dev auth-varnish LB cert

### DIFF
--- a/helm/k8s-pub-auth-varnish/app-configs/k8s-pub-auth-varnish_publishing.yaml
+++ b/helm/k8s-pub-auth-varnish/app-configs/k8s-pub-auth-varnish_publishing.yaml
@@ -2,7 +2,7 @@
 service:
   name: auth-varnish
   # using the content test certificate by default
-  certificateAwsArn: "arn:aws:acm:eu-west-1:070529446553:certificate/53071112-759c-4875-97e2-c62425df1381"
+  certificateAwsArn: "arn:aws:acm:eu-west-1:070529446553:certificate/a6ab3d87-cdae-4db4-838f-3dbce570ad47"
   
 elb:
   tags: "systemCode=upp,teamDL=universal.publishing.platform@ft.com,environment=d"

--- a/helm/k8s-pub-auth-varnish/values.yaml
+++ b/helm/k8s-pub-auth-varnish/values.yaml
@@ -10,4 +10,4 @@ image:
   repository: coco/k8s-pub-auth-varnish
   pullPolicy: IfNotPresent
 elbRegistrator:
-  image: "coco/coco-elb-dns-registrator:5.1.0"
+  image: "coco/coco-elb-dns-registrator:5.1.1"


### PR DESCRIPTION
As part of the migration to upp.ft.com a different certificate is required. This change sets the *.upp.ft.com certificate to be attached to the pub varnish service LB of the clusters.
