### PR TITLE
Change service cert to *.upp.ft.com on US staging

### DIFF
--- a/helm/k8s-pub-auth-varnish/app-configs/k8s-pub-auth-varnish_publishing_staging_us.yaml
+++ b/helm/k8s-pub-auth-varnish/app-configs/k8s-pub-auth-varnish_publishing_staging_us.yaml
@@ -1,7 +1,7 @@
 # Values used for the deployed application.
 service:
   name: auth-varnish
-  certificateAwsArn: "arn:aws:acm:us-east-1:469211898354:certificate/bde07970-60f9-4683-a367-fdf05b276b0a"
+  certificateAwsArn: "arn:aws:acm:us-east-1:469211898354:certificate/58bea0ec-c4c5-4d21-9009-c086e5cac77f"
 
 elb:
   tags: "systemCode=upp,teamDL=universal.publishing.platform@ft.com,environment=t"


### PR DESCRIPTION
As part of the migration to upp.ft.com a different certificate is
required. This change sets the *.upp.ft.com certificate to be attached
to the LBs of the clusters.