### PR TITLE
Feature/uppsf 4336 upgrade base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:bionic
+FROM ubuntu:jammy
 
 ENV VARNISHSRC=/usr/include/varnish VMODDIR=/usr/lib/varnish/vmods
 
@@ -7,14 +7,14 @@ WORKDIR /
 RUN apt-get update && \
     apt-get install -y curl gnupg2
 
-# install varnish 6.0-lts
+# install varnish 6.0-lts dependencies
 RUN curl -L https://packagecloud.io/varnishcache/varnish60lts/gpgkey | apt-key add - && \
-    echo "deb https://packagecloud.io/varnishcache/varnish60lts/ubuntu/ bionic main" | tee /etc/apt/sources.list.d/varnish-cache.list && \
+    echo "deb https://packagecloud.io/varnishcache/varnish60lts/ubuntu/ jammy main" | tee /etc/apt/sources.list.d/varnish-cache.list && \
     apt-get update && \
-    apt-get install -y libgetdns-dev varnish=6.0.11-1~bionic varnish-dev=6.0.11-1~bionic
+    apt-get install -y libgetdns-dev varnish=6.0.11-1~jammy varnish-dev=6.0.11-1~jammy
 
 # install varnish-modules
-RUN apt-get install -y git automake autoconf libtool python3 make python-docutils jq && \
+RUN apt-get install -y git automake autoconf libtool python3 make docutils-common jq && \
     git clone -b 6.0-lts https://github.com/varnish/varnish-modules.git && \
     mkdir /aclocal && \
     cd /varnish-modules && \
@@ -37,7 +37,7 @@ RUN  cd /vmod-basicauth && \
     make install
 
 # cleanup
-RUN  apt-get remove -y curl gnupg2 git git varnish-dev automake autoconf libtool python3 make python-docutils jq && \
+RUN  apt-get remove -y curl gnupg2 git git varnish-dev automake autoconf libtool python3 make docutils-common jq && \
     apt-get autoremove -y && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /vmod-basicauth

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,40 +2,45 @@ FROM ubuntu:bionic
 
 ENV VARNISHSRC=/usr/include/varnish VMODDIR=/usr/lib/varnish/vmods
 
-COPY vmod-basicauth-1.9/ /vmod-basicauth
+WORKDIR /
 
 RUN apt-get update && \
     apt-get install -y curl gnupg2
 
+# install varnish 6.0-lts
 RUN curl -L https://packagecloud.io/varnishcache/varnish60lts/gpgkey | apt-key add - && \
     echo "deb https://packagecloud.io/varnishcache/varnish60lts/ubuntu/ bionic main" | tee /etc/apt/sources.list.d/varnish-cache.list && \
     apt-get update && \
     apt-get install -y libgetdns-dev varnish=6.0.11-1~bionic varnish-dev=6.0.11-1~bionic
 
+# install varnish-modules
 RUN apt-get install -y git automake autoconf libtool python3 make python-docutils jq && \
-  cd / && echo "-------basicauth-build-------" && \
-  git clone -b 6.0-lts https://github.com/varnish/varnish-modules.git && \
-  mkdir /aclocal && \
-  cd varnish-modules && \
-  #git checkout  f771780801b5cf8b77954226a4f623fac759cd1e && \
-  autoreconf -f -i && \
-  ./bootstrap && \
-  ./configure && \
-  make  && \
-  make install && \
-  cd /vmod-basicauth && \
-  autoreconf -f -i && \
-  mkdir -p /usr/include/varnish/bin/varnishtest/ && \
-  ln -s /usr/bin/varnishtest /usr/include/varnish/bin/varnishtest/varnishtest && \
-  mkdir -p /usr/include/varnish/lib/libvcc/ && \
-  ln -s /usr/share/varnish/vmodtool.py /usr/include/varnish/lib/libvcc/vmodtool.py && \
-  ./configure && \
-  make && \
-  make install && \
-  apt-get remove -y curl gnupg2 git git varnish-dev automake autoconf libtool python3 make python-docutils jq && \
-  apt-get autoremove -y && \
-  apt-get clean && \
-  rm -rf /var/lib/apt/lists/* /vmod-basicauth
+    git clone -b 6.0-lts https://github.com/varnish/varnish-modules.git && \
+    mkdir /aclocal && \
+    cd /varnish-modules && \
+    autoreconf -f -i && \
+    ./bootstrap && \
+    ./configure && \
+    make  && \
+    make install
+
+# install vmod-basicauth
+COPY vmod-basicauth-1.9/ /vmod-basicauth
+RUN  cd /vmod-basicauth && \
+    autoreconf -f -i && \
+    mkdir -p /usr/include/varnish/bin/varnishtest/ && \
+    ln -s /usr/bin/varnishtest /usr/include/varnish/bin/varnishtest/varnishtest && \
+    mkdir -p /usr/include/varnish/lib/libvcc/ && \
+    ln -s /usr/share/varnish/vmodtool.py /usr/include/varnish/lib/libvcc/vmodtool.py && \
+    ./configure && \
+    make && \
+    make install
+
+# cleanup
+RUN  apt-get remove -y curl gnupg2 git git varnish-dev automake autoconf libtool python3 make python-docutils jq && \
+    apt-get autoremove -y && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* /vmod-basicauth
 
 COPY default.vcl /etc/varnish/default.vcl
 COPY start.sh /start.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,26 +1,21 @@
-FROM ubuntu:jammy
-
-ENV VARNISHSRC=/usr/include/varnish VMODDIR=/usr/lib/varnish/vmods
+FROM ubuntu:jammy as build
 
 WORKDIR /
 
-RUN apt-get update && \
-    apt-get install -y curl gnupg2
-
 # install varnish 6.0-lts dependencies
-RUN curl -L https://packagecloud.io/varnishcache/varnish60lts/gpgkey | apt-key add - && \
+RUN apt-get update && \
+    apt-get install -y curl gnupg2 && \
+    curl -L https://packagecloud.io/varnishcache/varnish60lts/gpgkey | apt-key add - && \
     echo "deb https://packagecloud.io/varnishcache/varnish60lts/ubuntu/ jammy main" | tee /etc/apt/sources.list.d/varnish-cache.list && \
     apt-get update && \
     apt-get install -y libgetdns-dev varnish=6.0.11-1~jammy varnish-dev=6.0.11-1~jammy
 
 # install varnish-modules
-RUN apt-get install -y git automake autoconf libtool python3 make docutils-common jq && \
+RUN apt-get install -y git automake autoconf libtool python3 make docutils-common && \
     git clone -b 6.0-lts https://github.com/varnish/varnish-modules.git && \
-    mkdir /aclocal && \
     cd /varnish-modules && \
-    autoreconf -f -i && \
     ./bootstrap && \
-    ./configure && \
+    ./configure --prefix=/build && \
     make  && \
     make install
 
@@ -28,19 +23,22 @@ RUN apt-get install -y git automake autoconf libtool python3 make docutils-commo
 COPY vmod-basicauth-1.9/ /vmod-basicauth
 RUN  cd /vmod-basicauth && \
     autoreconf -f -i && \
-    mkdir -p /usr/include/varnish/bin/varnishtest/ && \
-    ln -s /usr/bin/varnishtest /usr/include/varnish/bin/varnishtest/varnishtest && \
-    mkdir -p /usr/include/varnish/lib/libvcc/ && \
-    ln -s /usr/share/varnish/vmodtool.py /usr/include/varnish/lib/libvcc/vmodtool.py && \
-    ./configure && \
+    ./configure --with-vmoddir="/build/lib/varnish/vmods" && \
     make && \
     make install
 
-# cleanup
-RUN  apt-get remove -y curl gnupg2 git git varnish-dev automake autoconf libtool python3 make docutils-common jq && \
-    apt-get autoremove -y && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/* /vmod-basicauth
+FROM ubuntu:jammy
+
+# install varnish 6.0-lts dependencies
+RUN apt-get update && \
+    apt-get install -y curl gnupg2 && \
+    curl -L https://packagecloud.io/varnishcache/varnish60lts/gpgkey | apt-key add - && \
+    echo "deb https://packagecloud.io/varnishcache/varnish60lts/ubuntu/ jammy main" | tee /etc/apt/sources.list.d/varnish-cache.list && \
+    apt-get update && \
+    apt-get install -y varnish=6.0.11-1~jammy
+
+COPY --from=build /build/lib/varnish/vmods/ /usr/lib/varnish/vmods/
+COPY --from=build /build/share/ /usr/share/
 
 COPY default.vcl /etc/varnish/default.vcl
 COPY start.sh /start.sh


### PR DESCRIPTION
# Description

## What

- Change the base Dockerfile image to Ubuntu 22.04.
- Use Varnish 6.0 LTS
- Use varnish-modules 6.0 LTS branch instead of specific commit.
- Separate the Dockerfile to build and run stages

## Why

https://financialtimes.atlassian.net/browse/UPPSF-4336

## Anything, in particular, you'd like to highlight to reviewers

The base image was changed from Alpine to Ubuntu, because the latest version of alpine (3.17) does not have build for Varnish 6. And the current vcl does not work with v7.

For varnish-modules works with 6.0-lts branch. Not sure what was the reason for using the specific commit. 

## Scope and particulars of this PR (Please tick all that apply)

- [ ] Tech hygiene (dependency updating & other tech debt)
- [ ] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Breaking change
- [ ] Minor change (e.g. fixing a typo, adding config)

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)
